### PR TITLE
Add support for semitones in playNote and playSong

### DIFF
--- a/firmware/InternetButton.cpp
+++ b/firmware/InternetButton.cpp
@@ -207,13 +207,13 @@ uint8_t InternetButton::lowestLed(){
 void InternetButton::playSong(String song){
     char inputStr[200];
     song.toCharArray(inputStr,200);
-    
+
     Serial.println(inputStr);
-    
+
     char *note = strtok(inputStr,",");
     char *duration = strtok(NULL,",");
     playNote(note,atoi(duration));
-    
+
     while(duration != NULL){
         note = strtok(NULL,",");
         Serial.println(note);
@@ -226,22 +226,30 @@ void InternetButton::playSong(String song){
     }
 }
 
+// Params:
+//     note - String in the form {NOTE}{OCTAVE}
 void InternetButton::playNote(String note, int duration){
     int noteNum = 0;
     int octave = 5;
+    int octaveIdx = 1;
     int freq = 256;
-    
-     //if(9 - int(command.charAt(1)) != null){
+    int semitone = 0;
+
+    //if(9 - int(command.charAt(1)) != null){
+    if (note.charAt(1) == '#') {
+        semitone = 1;
+        octaveIdx = 2;
+    }
     char octavo[5];
-    String tempString = note.substring(1,2);
+    String tempString = note.substring(octaveIdx,octaveIdx+1);
     tempString.toCharArray(octavo,5);
     octave = atoi(octavo);
     //}
-    
+
     if(duration != 0){
         duration = 1000/duration;
     }
-    
+
     switch(note.charAt(0)){
         case 'C':
             noteNum = 0;
@@ -271,12 +279,14 @@ void InternetButton::playNote(String note, int duration){
             break;
             //return -1;
     }
-    
+
+    noteNum += semitone;
+
     // based on equation at http://www.phy.mtu.edu/~suits/NoteFreqCalcs.html and the Verdi tuning
     // fn = f0*(2^1/12)^n where n = number of half-steps from the reference frequency f0
     freq = float(256*pow(1.05946,(     12.0*(octave-4)        +noteNum)));
     //          C4^  (2^1/12)^    12 half-steps in an octave      ^how many extra half-steps within that octave, 0 for a C
-    
+
     tone(D0,int(freq),duration);
     delay(duration);
     noTone(D0);

--- a/firmware/InternetButton.cpp
+++ b/firmware/InternetButton.cpp
@@ -239,6 +239,9 @@ void InternetButton::playNote(String note, int duration){
     if (note.charAt(1) == '#') {
         semitone = 1;
         octaveIdx = 2;
+    } else if (note.charAt(1) == 'b') {
+        semitone = -1;
+        octaveIdx = 2;
     }
     char octavo[5];
     String tempString = note.substring(octaveIdx,octaveIdx+1);

--- a/firmware/examples/8_MakingMusic.cpp
+++ b/firmware/examples/8_MakingMusic.cpp
@@ -12,6 +12,9 @@ void setup() {
     // Types are note types that define duration so 
     // 8 is a 1/8th note and 4 is a 1/4 note
     b.playSong("C4,8,E4,8,G4,8,C5,8,G5,4");
+    // You can also use sharp and flat notes, like Eb5 and D#5
+    // in the following example:
+    b.playSong("E5,8,Eb5,8,E5,8,D#5,8,E5,8,B4,8,D5,8,C5,8,A3,4");
 }
 
 void loop() {


### PR DESCRIPTION
This lets users specify if they want a sharp or flat note by using '#' or 'b'.
