### PR TITLE
Update out of date URL

### DIFF
--- a/firmware/examples/7_Internet.cpp
+++ b/firmware/examples/7_Internet.cpp
@@ -3,7 +3,7 @@
 
 /* Let me show you how easy it is to put the Button on the Internet.
 Useful info, like how to access the data from your browser, can be
-found here: http://docs.particle.io/photon/firmware/#spark-function
+found here: https://docs.particle.io/reference/firmware/photon/#particle-function-
 
 The code to control the number of illuminated LEDs is here:
 https://github.com/spark/InternetButton/blob/master/controlKnob.html


### PR DESCRIPTION
Maintaining the links between example code and documentation seems like a challenge as the documentation evolves.  I'll submit an idea as a Issue in docs.
