### PR TITLE
Added support for variable LED lengths

### DIFF
--- a/firmware/InternetButton.h
+++ b/firmware/InternetButton.h
@@ -33,6 +33,7 @@ class InternetButton {
   void
     begin(void),
     begin(int i),
+    setNumLeds(uint8_t i),
     allLedsOff(void),
     allLedsOn(uint8_t r, uint8_t g, uint8_t b),
     ledOn(uint8_t i, uint8_t r, uint8_t g, uint8_t b),
@@ -249,7 +250,9 @@ class Adafruit_NeoPixel {
     setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b),
     setPixelColor(uint16_t n, uint32_t c),
     setBrightness(uint8_t),
-    clear(void);
+    clear(void),
+    updateLength(uint16_t n),
+    updateType(uint8_t t);
   uint8_t
    *getPixels() const,
     getBrightness(void) const;
@@ -262,15 +265,19 @@ class Adafruit_NeoPixel {
 
  private:
 
-  const uint16_t
+  uint16_t
     numLEDs,       // Number of RGB LEDs in strip
     numBytes;      // Size of 'pixels' buffer below
-  const uint8_t
+  uint8_t
     type;          // Pixel type flag (400 vs 800 KHz)
   uint8_t
     //pin,           // Output pin number
     brightness,
-   *pixels;        // Holds LED color values (3 bytes each)
+   *pixels,       // Holds LED color values (3 bytes each)
+   rOffset,       // Index of red byte within each 3- or 4-byte pixel
+   gOffset,       // Index of green byte
+   bOffset,       // Index of blue byte
+   wOffset;       // Index of white byte (same as rOffset if no white)
   uint32_t
     endTime;       // Latch timing reference
 };


### PR DESCRIPTION
Feature request: add support for more than 11 LEDs!

The latest revision of the InternetButton board has a space for a 12th LED, but this library is currently hardcoded to deal with 11. It would be great if users could solder on one more LED and enable it without having to mess with the library.

This commit introduces a new optional method `InternetButton::setNumLeds(uint8_t i)` which defaults to `PIXEL_COUNT` but allows users to change the number of active LEDs during runtime. This can be called in setup:

```
void setup() {
    // Defaults to 11, change to 12 if you wish
    b.setNumLeds(12);

    // Tell b to get everything ready to go
    b.begin();
}
```

To accommodate this method, a few pieces of [Adafruit_NeoPixel.cpp](https://github.com/adafruit/Adafruit_NeoPixel/blob/master/Adafruit_NeoPixel.cpp) were integrated, namely `updateType(uint8_t t)` and `updateLength(uint16_t n)`. Since type and length are now able to change, they are no longer constants and as such have been adjusted in the header.

Sub-12 lengths are still [supported as normal](https://github.com/spark/InternetButton/compare/master...emcniece:master#diff-e89301a5be41493599c8112ee68cf216R64), but now an extra check is performed to see if we have defined more than 11 LEDs.
