### PR TITLE
Update jQuery-Knob CDN link due to 404 error

### DIFF
--- a/controlKnob.html
+++ b/controlKnob.html
@@ -2,7 +2,7 @@
 <HTML>
 	<HEAD>
 	   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
-	   <script src="http://anthonyterrien.com/js/jquery.knob.js"></script>
+	   <script src="https://cdnjs.cloudflare.com/ajax/libs/jQuery-Knob/1.2.13/jquery.knob.min.js"></script>
        <meta name="viewport" content="user-scalable=no, initial-scale=1.0, maximum-scale=1.0, width=device-width">
 
 	</HEAD>


### PR DESCRIPTION
http://anthonyterrien.com/js/jquery.knob.js returns a 404 error so I suggest updating with the cloudflare CDN link.
