### PR TITLE
update neopixel library to 1.0

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=InternetButton
-version=0.1.13
+version=0.1.14
 license=LGPL
 author=Richard Whitney <richard@particle.io>
 sentence=Functions to make the Internet Button easy to use! If you have an original SparkButton, make sure to use `begin(1)`
-dependencies.neopixel=0.0.13
+dependencies.neopixel=1.0.0
 dependencies.particle_ADXL362=0.0.1
 url=https://github.com/particle-iot/InternetButton
 repository=https://github.com/particle-iot/InternetButton.git


### PR DESCRIPTION
We have at least one customer looking to use the Internet Button with 3rd gen devices via the classic adapter. Bumping the Neopixel library to 1.0 should do this.

NOTE: I don't have an adapter on hand so I can't (easily) verify that this is all that's required, I did manually test this library with version 1 of the neopixel library and a Photon-powered IB and there were no regressions. Once merged and pushed, I can work with a customer to test and verify.